### PR TITLE
Réorganisation du header + menu contextuel, fixes #1

### DIFF
--- a/Euro2016/Competition/calendrier.html
+++ b/Euro2016/Competition/calendrier.html
@@ -3,7 +3,6 @@
 <html>
 
     <head>
-    	<!-- En-tête de la page -->
         <meta charset="utf-8" />
         <link rel="icon" href="../favicon.ico" />
 
@@ -13,24 +12,29 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Calendrier des matchs</h1>
-        </header>
-        <nav class="Menu_principal">
-            <ul>
-                <li> <a href="../Competition/competition.html">Compétition </a>
-                    <ul>
-                        <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
-                        <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
-                        <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
-                    </ul></li>
-                <li> <a href="../Stades/stades.html">Stades </a></li>
-                <li> <a href="../Pays/pays.html">Pays </a></li>
-                <li> <a href="../contact.html">Contact </a></li>
-            </ul>
-        </nav>
+        <header>
+            <div class="banniere">
+                <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
 
+            <nav class="Menu_principal">
+                <ul>
+                    <li> <a href="../Competition/competition.html">Compétition </a>
+                        <ul>
+                            <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                            <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                            <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+                        </ul></li>
+                    <li> <a href="../Stades/stades.html">Stades </a></li>
+                    <li> <a href="../Pays/pays.html">Pays </a></li>
+                    <li> <a href="../contact.html">Contact </a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Corps de la page -->
         <section id="calendrier">
+            <h1>Calendrier et résultats des matchs</h1>
             <table>
                 <caption>Calendrier des matchs</caption>
                 <thead>
@@ -59,9 +63,27 @@
                 </tbody>
             </table>
         </section>
+
+        <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
+            <ul>
+                <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+            </ul>
+        </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+        
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
-            <p>Mentions légales</p>
+            <p><a href="mentions-legales.html">Mentions légales</a></p>
+            <p><a href="plan.html">Plan du site</a></p>
         </footer>
 
     </body>

--- a/Euro2016/Competition/competition.html
+++ b/Euro2016/Competition/competition.html
@@ -13,10 +13,13 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Présentation de la compétition</h1>
-        </header>
-        <nav class="Menu_principal">
+        <!-- En-tête de la page -->
+        <header>
+            <div class="banniere">
+                <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
+
+            <nav class="Menu_principal">
             <ul>
                 <li> <a href="../Competition/competition.html">Compétition </a>
                     <ul>
@@ -29,8 +32,11 @@
                 <li> <a href="../contact.html">Contact </a></li>
             </ul>
         </nav>
-
+        </header>
+        
+        <!-- Corps de la page -->
         <section id="competition">
+            <h1>Présentation de la compétition</h1>
             <p>
                 Vous trouverez dans cette section toutes les informations sur le déroulement de la <em>compétition</em> ! N'hésitez pas à consulter régulièrement les <a href="calendrier.html" title="Calendrier des matchs">résultats des matchs</a> !        
             </p>
@@ -38,13 +44,23 @@
                 Prochain <em>match</em> : X contre Y le date
             </p>
         </section>
-        <nav id="menu_competition"> 
+
+        <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
             <ul>
                 <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
                 <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
                 <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
             </ul>
         </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
             <p>Mentions légales</p>

--- a/Euro2016/Competition/groupes.html
+++ b/Euro2016/Competition/groupes.html
@@ -3,7 +3,6 @@
 <html>
 
     <head>
-    	<!-- En-tête de la page -->
         <meta charset="utf-8" />
         <link rel="icon" href="../favicon.ico" />
 
@@ -13,24 +12,30 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Composition des groupes</h1>
-        </header>
-        <nav class="Menu_principal">
-            <ul>
-                <li> <a href="../Competition/competition.html">Compétition </a>
-                    <ul>
-                        <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
-                        <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
-                        <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
-                    </ul></li>
-                <li> <a href="../Stades/stades.html">Stades </a></li>
-                <li> <a href="../Pays/pays.html">Pays </a></li>
-                <li> <a href="../contact.html">Contact </a></li>
-            </ul>
-        </nav>
+        <!-- En-tête de la page -->
+        <header>
+            <div class="banniere">
+                <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
 
+            <nav class="Menu_principal">
+                <ul>
+                    <li> <a href="../Competition/competition.html">Compétition </a>
+                        <ul>
+                            <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                            <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                            <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+                        </ul></li>
+                    <li> <a href="../Stades/stades.html">Stades </a></li>
+                    <li> <a href="../Pays/pays.html">Pays </a></li>
+                    <li> <a href="../contact.html">Contact </a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Corps de la page -->
         <section id="groupes">
+            <hi>Composition des groupes</h1>
             <p>
                 Les 24 pays qualifiés sont répartis en 6 groupes. Les deux premiers de chaque groupe et les quatre meilleurs troisièmes se qualifieront pour la phase à élimination directe.
             </p>
@@ -130,9 +135,27 @@
                 </tr>
             </table>
         </section>
+
+        <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
+            <ul>
+                <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+            </ul>
+        </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
-            <p>Mentions légales</p>
+            <p><a href="mentions-legales.html">Mentions légales</a></p>
+            <p><a href="plan.html">Plan du site</a></p>
         </footer>
 
     </body>

--- a/Euro2016/Competition/organigramme.html
+++ b/Euro2016/Competition/organigramme.html
@@ -3,7 +3,6 @@
 <html>
 
     <head>
-    	<!-- En-tête de la page -->
         <meta charset="utf-8" />
         <link rel="icon" href="../favicon.ico" />
 
@@ -13,31 +12,55 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Bienvenue sur le site de la coupe d'Europe 2016</h1>
-        </header>
-        <nav class="Menu_principal">
-            <ul>
-                <li> <a href="../Competition/competition.html">Compétition </a>
-                    <ul>
-                        <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
-                        <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
-                        <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
-                    </ul></li>
-                <li> <a href="../Stades/stades.html">Stades </a></li>
-                <li> <a href="../Pays/pays.html">Pays </a></li>
-                <li> <a href="../contact.html">Contact </a></li>
-            </ul>
-        </nav>
+        <!-- En-tête de la page -->
+        <header>
+            <div class="banniere">
+                <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
 
+            <nav class="Menu_principal">
+                <ul>
+                    <li> <a href="../Competition/competition.html">Compétition </a>
+                        <ul>
+                            <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                            <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                            <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+                        </ul></li>
+                    <li> <a href="../Stades/stades.html">Stades </a></li>
+                    <li> <a href="../Pays/pays.html">Pays </a></li>
+                    <li> <a href="../contact.html">Contact </a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Corps de la page -->
         <section id="Presentation_du_site">
+            <h1>Titre de la page</hi>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id nunc non metus tempus placerat. Donec sit amet nibh id metus sodales hendrerit vitae id erat. Nam bibendum mi quis metus viverra imperdiet. Praesent vitae malesuada ante. Nullam efficitur, augue eu ultrices semper, nisl tortor porta dui, eu ultrices est turpis ut arcu. Donec auctor lorem ut orci aliquet, et suscipit libero finibus. Duis augue sapien, mollis in mi non, pretium gravida est. Donec laoreet nulla ligula, eget varius eros commodo et. Morbi eu turpis sed nunc malesuada venenatis. In tincidunt laoreet neque, a posuere urna molestie id. Vivamus facilisis in lorem eget porttitor. 
             </p>
         </section>
+
+        <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
+            <ul>
+                <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+            </ul>
+        </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
-            <p>Mentions légales</p>
+            <p><a href="mentions-legales.html">Mentions légales</a></p>
+            <p><a href="plan.html">Plan du site</a></p>
         </footer>
 
     </body>

--- a/Euro2016/Pays/pays.html
+++ b/Euro2016/Pays/pays.html
@@ -3,7 +3,6 @@
 <html>
 
     <head>
-    	<!-- En-tête de la page -->
         <meta charset="utf-8" />
         <link rel="icon" href="../favicon.ico" />
 
@@ -13,31 +12,55 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Bienvenue sur le site de la coupe d'Europe 2016</h1>
-        </header>
-        <nav class="Menu_principal">
-            <ul>
-                <li> <a href="../Competition/competition.html">Compétition </a>
-                    <ul>
-                        <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
-                        <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
-                        <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
-                    </ul></li>
-                <li> <a href="../Stades/stades.html">Stades </a></li>
-                <li> <a href="../Pays/pays.html">Pays </a></li>
-                <li> <a href="../contact.html">Contact </a></li>
-            </ul>
-        </nav>
+        <!-- En-tête de la page -->
+        <header>
+            <div class="banniere">
+                <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
 
+            <nav class="Menu_principal">
+                <ul>
+                    <li> <a href="../Competition/competition.html">Compétition </a>
+                        <ul>
+                            <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                            <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                            <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+                        </ul></li>
+                    <li> <a href="../Stades/stades.html">Stades </a></li>
+                    <li> <a href="../Pays/pays.html">Pays </a></li>
+                    <li> <a href="../contact.html">Contact </a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Corps de la page -->
         <section id="Presentation_du_site">
+            <h1>Titre de la page</h1>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id nunc non metus tempus placerat. Donec sit amet nibh id metus sodales hendrerit vitae id erat. Nam bibendum mi quis metus viverra imperdiet. Praesent vitae malesuada ante. Nullam efficitur, augue eu ultrices semper, nisl tortor porta dui, eu ultrices est turpis ut arcu. Donec auctor lorem ut orci aliquet, et suscipit libero finibus. Duis augue sapien, mollis in mi non, pretium gravida est. Donec laoreet nulla ligula, eget varius eros commodo et. Morbi eu turpis sed nunc malesuada venenatis. In tincidunt laoreet neque, a posuere urna molestie id. Vivamus facilisis in lorem eget porttitor. 
             </p>
         </section>
+
+        <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
+            <ul>
+                <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+            </ul>
+        </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
-            <p>Mentions légales</p>
+            <p><a href="mentions-legales.html">Mentions légales</a></p>
+            <p><a href="plan.html">Plan du site</a></p>
         </footer>
 
     </body>

--- a/Euro2016/Stades/stades.html
+++ b/Euro2016/Stades/stades.html
@@ -3,7 +3,6 @@
 <html>
 
     <head>
-    	<!-- En-tête de la page -->
         <meta charset="utf-8" />
         <link rel="icon" href="../favicon.ico" />
 
@@ -13,31 +12,55 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Bienvenue sur le site de la coupe d'Europe 2016</h1>
-        </header>
-        <nav class="Menu_principal">
-            <ul>
-                <li> <a href="../Competition/competition.html">Compétition </a>
-                    <ul>
-                        <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
-                        <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
-                        <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
-                    </ul></li>
-                <li> <a href="../Stades/stades.html">Stades </a></li>
-                <li> <a href="../Pays/pays.html">Pays </a></li>
-                <li> <a href="../contact.html">Contact </a></li>
-            </ul>
-        </nav>
+        <!-- En-tête de la page -->
+        <header>
+            <div class="banniere">
+                <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
 
+            <nav class="Menu_principal">
+                <ul>
+                    <li> <a href="../Competition/competition.html">Compétition </a>
+                        <ul>
+                            <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                            <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                            <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+                        </ul></li>
+                    <li> <a href="../Stades/stades.html">Stades </a></li>
+                    <li> <a href="../Pays/pays.html">Pays </a></li>
+                    <li> <a href="../contact.html">Contact </a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Corps de la page -->
         <section id="Presentation_du_site">
+            <h1>Titre</h1>
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id nunc non metus tempus placerat. Donec sit amet nibh id metus sodales hendrerit vitae id erat. Nam bibendum mi quis metus viverra imperdiet. Praesent vitae malesuada ante. Nullam efficitur, augue eu ultrices semper, nisl tortor porta dui, eu ultrices est turpis ut arcu. Donec auctor lorem ut orci aliquet, et suscipit libero finibus. Duis augue sapien, mollis in mi non, pretium gravida est. Donec laoreet nulla ligula, eget varius eros commodo et. Morbi eu turpis sed nunc malesuada venenatis. In tincidunt laoreet neque, a posuere urna molestie id. Vivamus facilisis in lorem eget porttitor. 
             </p>
         </section>
+
+       <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
+            <ul>
+                <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+            </ul>
+        </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
-            <p>Mentions légales</p>
+            <p><a href="mentions-legales.html">Mentions légales</a></p>
+            <p><a href="plan.html">Plan du site</a></p>
         </footer>
 
     </body>

--- a/Euro2016/contact.html
+++ b/Euro2016/contact.html
@@ -3,7 +3,6 @@
 <html>
 
     <head>
-    	<!-- En-tête de la page -->
         <meta charset="utf-8" />
         <link rel="icon" href="favicon.ico" />
 
@@ -13,31 +12,54 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="index.html"><img src="Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Bienvenue sur le site de la coupe d'Europe 2016</h1>
-        </header>
-        <nav class="Menu_principal">
-            <ul>
-                <li> <a href="Competition/competition.html">Compétition </a>
-                    <ul>
-                        <li> <a href="Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
-                        <li> <a href ="Competition/groupes.html">Composition des groupes </a></li>
-                        <li> <a href="Competition/organigramme.html">Organigramme </a></li>
-                    </ul></li>
-                <li> <a href="Stades/stades.html">Stades </a></li>
-                <li> <a href="Pays/pays.html">Pays </a></li>
-                <li> <a href="contact.html">Contact </a></li>
-            </ul>
-        </nav>
+        <!-- En-tête de la page -->
+        <header>
+            <div class="banniere">
+                <a href="index.html"><img src="Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
 
+            <nav class="Menu_principal">
+                <ul>
+                    <li> <a href="../Competition/competition.html">Compétition </a>
+                        <ul>
+                            <li> <a href="Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                            <li> <a href ="Competition/groupes.html">Composition des groupes </a></li>
+                            <li> <a href="Competition/organigramme.html">Organigramme </a></li>
+                        </ul></li>
+                    <li> <a href="Stades/stades.html">Stades </a></li>
+                    <li> <a href="Pays/pays.html">Pays </a></li>
+                    <li> <a href="contact.html">Contact </a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Corps de la page -->
         <section id="Presentation_du_site">
             <p>
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id nunc non metus tempus placerat. Donec sit amet nibh id metus sodales hendrerit vitae id erat. Nam bibendum mi quis metus viverra imperdiet. Praesent vitae malesuada ante. Nullam efficitur, augue eu ultrices semper, nisl tortor porta dui, eu ultrices est turpis ut arcu. Donec auctor lorem ut orci aliquet, et suscipit libero finibus. Duis augue sapien, mollis in mi non, pretium gravida est. Donec laoreet nulla ligula, eget varius eros commodo et. Morbi eu turpis sed nunc malesuada venenatis. In tincidunt laoreet neque, a posuere urna molestie id. Vivamus facilisis in lorem eget porttitor. 
             </p>
         </section>
+       
+       <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
+            <ul>
+                <li> <a href="Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                <li> <a href ="Competition/groupes.html">Composition des groupes </a></li>
+                <li> <a href="Competition/organigramme.html">Organigramme </a></li>
+            </ul>
+        </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
-            <p>Mentions légales</p>
+            <p><a href="mentions-legales.html">Mentions légales</a></p>
+            <p><a href="plan.html">Plan du site</a></p>
         </footer>
 
     </body>

--- a/Euro2016/index.html
+++ b/Euro2016/index.html
@@ -3,7 +3,6 @@
 <html>
 
     <head>
-    	<!-- En-tête de la page -->
         <meta charset="utf-8" />
         <link rel="icon" href="favicon.ico" />
 
@@ -13,23 +12,28 @@
 
     <body>
     	
-        <header class="En-tete">
-            <a href="/index.html"><img src="Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Bienvenue sur le site de la coupe d'Europe 2016</h1>
-        </header>
-        <nav class="Menu_principal">
-            <ul>
-                <li> <a href="Competition/competition.html">Compétition </a>
-                    <ul>
-                        <li> <a href="Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
-                        <li> <a href ="Competition/groupes.html">Composition des groupes </a></li>
-                        <li> <a href="Competition/organigramme.html">Organigramme </a></li>
-                    </ul></li>
-                <li> <a href="Stades/stades.html">Stades </a></li>
-                <li> <a href="Pays/pays.html">Pays </a></li>
-                <li> <a href="contact.html">Contact </a></li>
-            </ul>
-        </nav>
+        <!-- En-tête de la page -->
+        <header>
+            <div class="banniere">
+                <a href="../index.html"><img src="../Images/logo_UEFA.png" width="150px" height="211px" alt="logo de l'UEFA 2016"/></a><h1>Euro 2016 de football</h1>
+            </div>
 
+            <nav class="Menu_principal">
+                <ul>
+                    <li> <a href="../Competition/competition.html">Compétition </a>
+                        <ul>
+                            <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                            <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                            <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+                        </ul></li>
+                    <li> <a href="../Stades/stades.html">Stades </a></li>
+                    <li> <a href="../Pays/pays.html">Pays </a></li>
+                    <li> <a href="../contact.html">Contact </a></li>
+                </ul>
+            </nav>
+        </header>
+
+        <!-- Corps de la page -->
         <section id="Presentation_du_site">
             <p>
                 Retrouvez ici toutes les informations sur la <strong>coupe d'Europe</strong> de <strong>football</strong> de l'<em>UEFA</em> 2016. 
@@ -43,11 +47,27 @@
                 </p>
             </article>
         </section>
+
+        <section class="colonne-gauche">
+        <nav class="menu-contextuel" id="menu-competition"> 
+            <ul>
+                <li> <a href="../Competition/calendrier.html" title="Calendrier des matches"> Calendrier des matches </a></li>
+                <li> <a href ="../Competition/groupes.html">Composition des groupes </a></li>
+                <li> <a href="../Competition/organigramme.html">Organigramme </a></li>
+            </ul>
+        </nav>
+        <aside>
+            <p>
+                Un petit encart pour mettre des trucs
+            </p>
+        </aside>
+        </section>
+
+        <!--Pied de page -->
         <footer>
             <p>© M.C. et C.L. 2015. <br/>Tous droits réservés. </p>
-            <p>Mentions légales</p>
-
-            
+            <p><a href="mentions-legales.html">Mentions légales</a></p>
+            <p><a href="plan.html">Plan du site</a></p>
         </footer>
 
     </body>


### PR DESCRIPTION
Le menu principal a été déplacé dans le header, le titre de la page est
maintenant dans la section principale. Ajout d'un menu contextuel pour
chaque page et lien vers le plan du site et les mentions légales dans le
footer.
